### PR TITLE
fixes address alias transaction

### DIFF
--- a/e2e/pageDetail/transactions/addressAlias.spec.js
+++ b/e2e/pageDetail/transactions/addressAlias.spec.js
@@ -30,7 +30,7 @@ describe('Symbol Explorer Transaction detail page for Address Alias', () => {
         })
 
         it('render correct transaction detail titles', () => {
-            const items = ['Type', 'Type', 'Alias Action', 'Namespace ID', 'Name']
+            const items = ['Type', 'Type', 'Alias Action', 'Namespace ID', 'Name', 'Address']
             cy.renderFieldInTable("transactionDetailTitle", items)
         })
 

--- a/src/components/transaction-graphic/AddressAliasGraphic.vue
+++ b/src/components/transaction-graphic/AddressAliasGraphic.vue
@@ -23,7 +23,7 @@
                 :y="objectPositionY"
                 :width="subjectWidth"
                 :height="subjectHeight"
-                :address="signer"
+                :address="address"
             />
             <Arrow :x="arrowPositionX" :y="arrowPositionY" />
             <NamespaceCircle
@@ -69,6 +69,11 @@ export default {
       default: ''
     },
     signer: {
+      type: String,
+      required: true,
+      default: ''
+    },
+    address: {
       type: String,
       required: true,
       default: ''

--- a/src/config/key-redirects.json
+++ b/src/config/key-redirects.json
@@ -13,7 +13,6 @@
     "restrictionAddressValues": "account",
     "restrictionAddressAdditions": "account",
     "restrictionAddressDeletions": "account",
-    "accountAliasName": "account",
     "cosignatories": "account",
     "multisigAddresses_": "account",
     "linkedAccountAddress": "account",
@@ -43,6 +42,7 @@
     "parentId": "namespace",
     "linkedNamespace": "namespace",
     "mosaicAliasName": "namespace",
+    "accountAliasName": "namespace",
     "targetNamespaceId": "namespace",
     "unresolved": "namespace"
 }

--- a/src/infrastructure/TransactionService.js
+++ b/src/infrastructure/TransactionService.js
@@ -280,7 +280,8 @@ class TransactionService {
         transactionDescriptor: 'transactionDescriptor_' + transactionBody.type,
         aliasAction: Constants.AliasAction[transactionBody.aliasAction],
         namespaceId: transactionBody.namespaceId.toHex(),
-        namespaceName: transactionBody.namespaceId.fullName
+        namespaceName: transactionBody.namespaceId.fullName,
+        address: transactionBody.address.address
       }
 
     case TransactionType.MOSAIC_ALIAS:


### PR DESCRIPTION
Address alias transaction

### Updated
- Transaction Graphic show the correct linked address

### Added
- linked `address` into transaction detail.

Resolved: #534 